### PR TITLE
Add Glide task

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -127,6 +127,33 @@ tree.
   follow Go conventions.  For example, if your project is located at `https://github.com/username/myproject`, the value
   of this parameter should be `github.com/username/myproject`.
 
+## Go Glide Task
+
+The **Go Glide** task will retrieve a Go project's dependencies provided they have been defined using
+[Glide](https://github.com/Masterminds/glide), i.e. there is a `glide.yaml` file available in the Go project's source
+tree.
+
+### Parameters
+
+* **GOROOT**
+
+  The value of the `GOROOT` environment variable for the Go installation used to build the Go project.  The Go Plugin
+  for Bamboo will attempt to automatically set this value using either the value of the `GOROOT` environment variable
+  defined on the Bamboo server or by using `/path/to/go/bin/..`.  If the default value isn't appropriate for your
+  build you must change it.
+* **Source path**
+
+  A relative path pointing to the directory where your Go project source code has been checked out.  This path must
+  follow Go conventions.  For example, if your project is located at `https://github.com/username/myproject`, the value
+  of this parameter should be `github.com/username/myproject`.
+* **GOPATH**
+
+  A path pointing to the directory where your Go src directory exists. This can be relative to the project directory
+  or absolute.
+* **Glide Executable path**
+
+  The absolute path to the Glide executable on the server.
+
 ## Go Test Runner Task
 
 The **Go Test Runner Task** will run a Go project's tests and save the output for parsing by the [Go Test Parser Task](#go-test-parser-task).

--- a/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/glide/GoGlideTaskConfiguration.java
+++ b/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/glide/GoGlideTaskConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * Go Plugin for Bamboo
+ * %%
+ * Copyright (C) 2016 Andrew Warren-Love
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.handcraftedbits.bamboo.plugin.go.task.glide;
+
+import com.atlassian.bamboo.task.TaskContext;
+import com.handcraftedbits.bamboo.plugin.go.task.common.GoPackageAwareTaskConfiguration;
+import com.handcraftedbits.bamboo.plugin.go.task.common.GoTaskHelper;
+import org.jetbrains.annotations.NotNull;
+
+final class GoGlideTaskConfiguration extends GoPackageAwareTaskConfiguration {
+     static final String PARAM_GLIDE_EXEC = "glideExec";
+     static final String PARAM_GOPATH = "goPath";
+
+     GoGlideTaskConfiguration (@NotNull final GoTaskHelper taskHelper, @NotNull final TaskContext taskContext) {
+          super(taskHelper, taskContext);
+     }
+
+     @NotNull
+     String getGlideExecutable () {
+          return getTaskContext().getConfigurationMap().get(GoGlideTaskConfiguration.PARAM_GLIDE_EXEC);
+     }
+
+     @NotNull
+     String getGoPath () {
+          return getTaskContext().getConfigurationMap().get(GoGlideTaskConfiguration.PARAM_GOPATH);
+     }
+}

--- a/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/glide/GoGlideTaskConfigurator.java
+++ b/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/glide/GoGlideTaskConfigurator.java
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * Go Plugin for Bamboo
+ * %%
+ * Copyright (C) 2016 Andrew Warren-Love
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.handcraftedbits.bamboo.plugin.go.task.glide;
+
+import com.atlassian.bamboo.process.EnvironmentVariableAccessor;
+import com.atlassian.bamboo.v2.build.agent.capability.CapabilityContext;
+import com.atlassian.struts.TextProvider;
+import com.handcraftedbits.bamboo.plugin.go.task.common.AbstractGoExecutableTaskConfigurator;
+import org.jetbrains.annotations.NotNull;
+
+public final class GoGlideTaskConfigurator extends AbstractGoExecutableTaskConfigurator {
+     public GoGlideTaskConfigurator (@NotNull final CapabilityContext capabilityContext,
+                                    @NotNull final EnvironmentVariableAccessor environmentVariableAccessor,
+                                    @NotNull final TextProvider textProvider) {
+          super(capabilityContext, environmentVariableAccessor, textProvider, false);
+
+          addParameter(GoGlideTaskConfiguration.PARAM_GLIDE_EXEC, "");
+          addParameter(GoGlideTaskConfiguration.PARAM_GOPATH, "");
+     }
+}

--- a/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/glide/GoGlideTaskType.java
+++ b/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/glide/GoGlideTaskType.java
@@ -2,7 +2,7 @@
  * #%L
  * Go Plugin for Bamboo
  * %%
- * Copyright (C) 2015 HandcraftedBits
+ * Copyright (C) 2016 Andrew Warren-Love
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.handcraftedbits.bamboo.plugin.go.task.dependency;
-
-import java.util.LinkedList;
-import java.util.List;
+package com.handcraftedbits.bamboo.plugin.go.task.glide;
 
 import com.atlassian.bamboo.process.EnvironmentVariableAccessor;
 import com.atlassian.bamboo.task.TaskContext;
@@ -31,14 +28,18 @@ import com.atlassian.bamboo.v2.build.agent.capability.CapabilityContext;
 import com.atlassian.struts.TextProvider;
 import com.atlassian.utils.process.ExternalProcess;
 import com.handcraftedbits.bamboo.plugin.go.task.common.AbstractGoTaskType;
-import com.handcraftedbits.bamboo.plugin.go.task.common.GoTaskConfiguration;
 import com.handcraftedbits.bamboo.plugin.go.task.common.ProcessHelper;
 import org.jetbrains.annotations.NotNull;
 
-public final class GoDependencyTaskType extends AbstractGoTaskType {
-     public GoDependencyTaskType (@NotNull final CapabilityContext capabilityContext,
-          @NotNull final EnvironmentVariableAccessor environmentVariableAccessor,
-          @NotNull final TextProvider textProvider) {
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public final class GoGlideTaskType extends AbstractGoTaskType {
+     public GoGlideTaskType (@NotNull final CapabilityContext capabilityContext,
+                            @NotNull final EnvironmentVariableAccessor environmentVariableAccessor,
+                            @NotNull final TextProvider textProvider) {
           super(capabilityContext, environmentVariableAccessor, textProvider);
      }
 
@@ -46,14 +47,17 @@ public final class GoDependencyTaskType extends AbstractGoTaskType {
      @Override
      public TaskResult execute (@NotNull final TaskContext taskContext) throws TaskException {
           final List<String> commandLine = new LinkedList<>();
-          final GoTaskConfiguration configuration = new GoTaskConfiguration(getTaskHelper(), taskContext);
+          final GoGlideTaskConfiguration configuration = new GoGlideTaskConfiguration(getTaskHelper(), taskContext);
           final ExternalProcess process;
           final ProcessHelper processHelper = getTaskHelper().createProcessHelper(taskContext);
 
-          commandLine.add(configuration.getGodepExecutable());
-          commandLine.add("restore");
+          commandLine.add(configuration.getGlideExecutable());
+          commandLine.add("install");
 
-          process = processHelper.executeProcess(commandLine, configuration.getSourcePath());
+          final Map<String, String> env = new HashMap<>();
+          env.put("GOPATH", configuration.getGoPath());
+
+          process = processHelper.executeProcess(commandLine, configuration.getSourcePath(), env);
 
           return TaskResultBuilder.newBuilder(taskContext).checkReturnCode(process, 0).build();
      }

--- a/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/godep/GoDependencyTaskConfigurator.java
+++ b/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/godep/GoDependencyTaskConfigurator.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.handcraftedbits.bamboo.plugin.go.task.dependency;
+package com.handcraftedbits.bamboo.plugin.go.task.godep;
 
 import com.atlassian.bamboo.process.EnvironmentVariableAccessor;
 import com.atlassian.bamboo.v2.build.agent.capability.CapabilityContext;

--- a/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/godep/GoDependencyTaskType.java
+++ b/src/main/java/com/handcraftedbits/bamboo/plugin/go/task/godep/GoDependencyTaskType.java
@@ -1,0 +1,60 @@
+/*
+ * #%L
+ * Go Plugin for Bamboo
+ * %%
+ * Copyright (C) 2015 HandcraftedBits
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.handcraftedbits.bamboo.plugin.go.task.godep;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.atlassian.bamboo.process.EnvironmentVariableAccessor;
+import com.atlassian.bamboo.task.TaskContext;
+import com.atlassian.bamboo.task.TaskException;
+import com.atlassian.bamboo.task.TaskResult;
+import com.atlassian.bamboo.task.TaskResultBuilder;
+import com.atlassian.bamboo.v2.build.agent.capability.CapabilityContext;
+import com.atlassian.struts.TextProvider;
+import com.atlassian.utils.process.ExternalProcess;
+import com.handcraftedbits.bamboo.plugin.go.task.common.AbstractGoTaskType;
+import com.handcraftedbits.bamboo.plugin.go.task.common.GoTaskConfiguration;
+import com.handcraftedbits.bamboo.plugin.go.task.common.ProcessHelper;
+import org.jetbrains.annotations.NotNull;
+
+public final class GoDependencyTaskType extends AbstractGoTaskType {
+     public GoDependencyTaskType (@NotNull final CapabilityContext capabilityContext,
+          @NotNull final EnvironmentVariableAccessor environmentVariableAccessor,
+          @NotNull final TextProvider textProvider) {
+          super(capabilityContext, environmentVariableAccessor, textProvider);
+     }
+
+     @NotNull
+     @Override
+     public TaskResult execute (@NotNull final TaskContext taskContext) throws TaskException {
+          final List<String> commandLine = new LinkedList<>();
+          final GoTaskConfiguration configuration = new GoTaskConfiguration(getTaskHelper(), taskContext);
+          final ExternalProcess process;
+          final ProcessHelper processHelper = getTaskHelper().createProcessHelper(taskContext);
+
+          commandLine.add(configuration.getGodepExecutable());
+          commandLine.add("restore");
+
+          process = processHelper.executeProcess(commandLine, configuration.getSourcePath());
+
+          return TaskResultBuilder.newBuilder(taskContext).checkReturnCode(process, 0).build();
+     }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -52,16 +52,29 @@
     <resource type="download" name="icon" location="com/handcraftedbits/bamboo/plugin/go/image/plugin-logo.png" />
   </taskType>
 
-  <!-- Go dependency task -->
+  <!-- Go godep task -->
   <taskType key="task.go.dependency" name="Go Dependency Fetcher"
-            class="com.handcraftedbits.bamboo.plugin.go.task.dependency.GoDependencyTaskType">
+            class="com.handcraftedbits.bamboo.plugin.go.task.godep.GoDependencyTaskType">
     <description>Fetches Go project dependencies</description>
     <category name="builder" />
     <help link="task.dependency.help.link" title="task.dependency.help.text" />
 
-    <configuration class="com.handcraftedbits.bamboo.plugin.go.task.dependency.GoDependencyTaskConfigurator" />
+    <configuration class="com.handcraftedbits.bamboo.plugin.go.task.godep.GoDependencyTaskConfigurator" />
     <resource type="freemarker" name="edit"
               location="com/handcraftedbits/bamboo/plugin/go/template/goDependencyTaskEdit.ftl" />
+    <resource type="download" name="icon" location="com/handcraftedbits/bamboo/plugin/go/image/plugin-logo.png" />
+  </taskType>
+
+  <!-- Go Glide task -->
+  <taskType key="task.go.glide" name="Glide Dependency Fetcher"
+            class="com.handcraftedbits.bamboo.plugin.go.task.glide.GoGlideTaskType">
+    <description>Fetches Go project dependencies</description>
+    <category name="builder" />
+    <help link="task.glide.help.link" title="task.glide.help.text" />
+
+    <configuration class="com.handcraftedbits.bamboo.plugin.go.task.glide.GoGlideTaskConfigurator" />
+    <resource type="freemarker" name="edit"
+              location="com/handcraftedbits/bamboo/plugin/go/template/goGlideTaskEdit.ftl" />
     <resource type="download" name="icon" location="com/handcraftedbits/bamboo/plugin/go/image/plugin-logo.png" />
   </taskType>
 

--- a/src/main/resources/com/handcraftedbits/bamboo/plugin/go/i18n/english.properties
+++ b/src/main/resources/com/handcraftedbits/bamboo/plugin/go/i18n/english.properties
@@ -63,9 +63,15 @@ task.common.field.sourcePath.description=The <em>source path</em> for the Go pro
   <b>''src/github.com/username/myproject''</b>).
 task.common.field.sourcePath.error=Source path is required.
 
-# Go dependency fetcher task
+# Go godep fetcher task
 task.dependency.help.link=https://github.com/handcraftedbits/go-bamboo-plugin/blob/release-1.0.0/doc/guide.md#go-dependency-fetcher-task
 task.dependency.help.text=How to use the Go Dependency Fetcher task
+
+# Glide glide fetcher task
+task.glide.help.link=https://github.com/handcraftedbits/go-bamboo-plugin/blob/release-1.0.0/doc/guide.md#go-glide-task
+task.glide.help.text=How to use the Go Glide task
+task.glide.field.glideExec=Glide Executable path
+task.glide.field.goPath=Path where Go src directory exists
 
 # Go test parser task
 task.parser.field.pattern=Go test result file pattern

--- a/src/main/resources/com/handcraftedbits/bamboo/plugin/go/template/goGlideTaskEdit.ftl
+++ b/src/main/resources/com/handcraftedbits/bamboo/plugin/go/template/goGlideTaskEdit.ftl
@@ -1,0 +1,7 @@
+[#include "macros.ftl"]
+
+[@goRootAndSourcePath /]
+
+[@s.textfield name="glideExec" labelKey="task.glide.field.glideExec" cssClass="long-field" required=true /]
+
+[@s.textfield name="goPath" labelKey="task.glide.field.goPath" cssClass="long-field" required=true /]


### PR DESCRIPTION
This adds a separate task to allow using Glide as the dependency manager instead of GoDep.
