### PR TITLE
'go test' output for '[build failed]' uses space instead of tab

### DIFF
--- a/src/main/java/com/handcraftedbits/bamboo/plugin/go/parser/GoTestParser.java
+++ b/src/main/java/com/handcraftedbits/bamboo/plugin/go/parser/GoTestParser.java
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class GoTestParser {
-     private static final Pattern patternPackageFinish = Pattern.compile("^(\\?   |ok  |FAIL)\t([^\t]+)\t(.*)$");
+     private static final Pattern patternPackageFinish = Pattern.compile("^(\\?   |ok  |FAIL)\t([^\t]+)\\s(.*)$");
      private static final Pattern patternTestFinish = Pattern.compile("^--- (FAIL|PASS|SKIP): ([^ ]+) \\(([^s]+)s\\)$");
 
      private GoTestParser () {


### PR DESCRIPTION
Basically I have made the 'patternPackageFinish' matcher regex more forgiving by allowing any whitespace to tokenise the last match group.